### PR TITLE
add missing 103 and update 308

### DIFF
--- a/contents/codes/103.md
+++ b/contents/codes/103.md
@@ -1,0 +1,31 @@
+---
+set: 1
+code: 103
+title: Early Hints
+references:
+    "C# HTTP Status Enum": "HttpStatusCode.EarlyHints"
+---
+### Early Hints
+
+This status code indicates to the client that the server is likely to send a final response with the header fields included in the informational response.
+
+Typically, a server will include the header fields sent in a 103 (Early Hints) response in the final response as well.  However, there might be cases when this is not desirable, such as when the server learns that the header fields in the 103 (Early Hints) response are not correct before the final response is sent.
+
+A client can speculatively evaluate the header fields included in a 103 (Early Hints) response while waiting for the final response.  For example, a client might recognize a Link header field value containing the relation type "preload" and start fetching the target resource.  However, these header fields only provide hints to the client; they do not replace the header fields on the final response.
+
+Aside from performance optimizations, such evaluation of the 103 (Early Hints) response's header fields MUST NOT affect how the final response is processed.  A client MUST NOT interpret the 103 (Early Hints) response header fields as if they applied to the informational response itself (e.g., as metadata about the 103 (Early Hints) response).
+
+A server MAY use a 103 (Early Hints) response to indicate only some of the header fields that are expected to be found in the final response.  A client SHOULD NOT interpret the nonexistence of a header field in a 103 (Early Hints) response as a speculation that the header field is unlikely to be part of the final response.
+
+### Checkpoint
+
+This code is the same as [308 Resume Incomplete](/308) except for the fact that it is sent
+as a provisional response rather than a final response.
+In other words, zero or more 103 responses can be sent in response to a request
+that is still being processed, after which a final response code must be sent.
+
+---
+
+* Source for Early Hints: [RFC8297 Section 2][1]
+
+[1]: <https://tools.ietf.org/html/rfc8297#section-2>

--- a/contents/codes/308.md
+++ b/contents/codes/308.md
@@ -6,6 +6,8 @@ references:
     "Symfony HTTP Status Constant": "Response::HTTP_PERMANENTLY_REDIRECT"
 ---
 
+### Permanent Redirect
+
 The target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.
 
 Clients with link editing capabilities ought to automatically re-link references to the effective request URI<sup>[1](#ref-1)</sup> to one or more of the new references sent by the server, where possible.
@@ -16,6 +18,20 @@ A 308 response is cacheable by default; i.e., unless otherwise indicated by the 
 
 Note: This status code is similar to [301 Moved Permanently](/301), except that it does not allow changing the request method from POST to GET.
 
+### Resume Incomplete
+
+Some applications may use 308 Resume Incomplete as a non-standard response.
+
+This status code indicates to the client that the server does not possess the
+complete byte range for the resume request to proceed but is still
+willing to continue the operation.
+It may include a Range header so that the client may minimize the amount
+of data that needs to be retransmitted by the ensuing resume requests.
+In the absence of any such Range header, the client should assume that
+the server has no stored bytes.
+It may include a Location header indicating the URI to which future
+resumable requests should be sent for this operation.
+
 ---
 
 * <span id="ref-1"><sup>1</sup> Effective Request URI
@@ -23,7 +39,9 @@ Note: This status code is similar to [301 Moved Permanently](/301), except that 
 * <span id="ref-2"><sup>2</sup> Location [RFC7231 Section 7.1.2][3]</span>
 * <span id="ref-3"><sup>3</sup> Calculating Heuristic Freshness
 [RFC7234 Section 4.2.2][4]</span>
-* Source: [RFC738 Section 3][1]
+* Sources:
+  * [RFC738 Section 3][1]
+  * [resumable HTTP requests](https://web.archive.org/web/20151013212135/http://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal#Status_Code:_308_Resume_Incomplete)
 
 [1]: <http://tools.ietf.org/html/rfc7538#section-3>
 [2]: <http://tools.ietf.org/html/rfc7230#section-5.5>


### PR DESCRIPTION
Google's proposal predates the RFC7238 by several years.
[It was spearheaded by the team behind Gears](https://developers.google.com/gdata/docs/resumable_upload) which used to be a builtin in Google Chrome.
