### PR TITLE
unlisted codes

### DIFF
--- a/templates/index.jade
+++ b/templates/index.jade
@@ -16,4 +16,5 @@ block contents
       ul
         li #[h2 !{group.title}]
         each code in group.items
-          li #[a(href='/#{code.code}') #[span !{code.code}] #{code.title}]
+          unless code.unlisted
+            li #[a(href='/#{code.code}') #[span !{code.code}] #{code.title}]


### PR DESCRIPTION
Adds support for hiding a code from the homepage by specifying `unlisted: true` in the front matter of the page