### PR TITLE
Fix symbol

### DIFF
--- a/contents/codes/424.md
+++ b/contents/codes/424.md
@@ -5,7 +5,7 @@ title: Failed Dependency
 references:
     ".NET HTTP Status Enum": "HttpStatusCode.FailedDependency"
     "Rust HTTP Status Constant": "http::StatusCode::FAILED_DEPENDENCY"
-    "Rails HTTP Status Symbol": "failed_dependency"
+    "Rails HTTP Status Symbol": ":failed_dependency"
     "Symfony HTTP Status Constant": "Response::HTTP_FAILED_DEPENDENCY"
     "Python HTTP Status Constant": "httplib.FAILED_DEPENDENCY"
 ---


### PR DESCRIPTION
In ruby symbols starts with a `:` sign