### PR TITLE
JSON endpoints

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,9 @@
-const excerpt = require('./lib/filters/excerpt');
+const {
+  decode,
+  excerpt,
+  firstParagraph,
+  removeHTMLElements
+} = require('./lib/filters');
 const pkg = require('./package.json');
 const _ = require('lodash');
 const EXCERPT_LENGTH = 400;
@@ -9,6 +14,9 @@ module.exports = function(eleventyConfig) {
   ["contents/**.ico", "contents/**.txt"]
     .forEach(file => eleventyConfig.addPassthroughCopy(file))
 
+  eleventyConfig.addFilter("decode", decode);
+  eleventyConfig.addFilter("deletehtml", (str => removeHTMLElements({ str, stripSpaces: true, tags: ['sup'] })))
+  eleventyConfig.addFilter("firstparagraph", firstParagraph)
   eleventyConfig.addFilter("excerpt", (str) => excerpt(str, EXCERPT_LENGTH));
 
   // Group status codes by category
@@ -16,6 +24,12 @@ module.exports = function(eleventyConfig) {
     return _.chain(collectionApi.getFilteredByGlob("./contents/codes/*.md"))
       .orderBy((post) => post.data.code)
       .groupBy((post) => post.data.set)
+      .value();
+  });
+
+  eleventyConfig.addCollection("codes_json", function(collectionApi) {
+    return _.chain(collectionApi.getFilteredByGlob("./contents/codes/*.md"))
+      .orderBy((post) => post.data.code)
       .value();
   });
 

--- a/contents/_data/categories.json
+++ b/contents/_data/categories.json
@@ -1,7 +1,7 @@
 {
-    "1": "1&times;&times; Informational",
-    "2": "2&times;&times; Success",
-    "3": "3&times;&times; Redirection",
-    "4": "4&times;&times; Client Error",
-    "5": "5&times;&times; Server Error"
+    "1": "Informational",
+    "2": "Success",
+    "3": "Redirection",
+    "4": "Client Error",
+    "5": "Server Error"
   }

--- a/contents/_data/site.json
+++ b/contents/_data/site.json
@@ -1,0 +1,4 @@
+{
+    "name": "httpstatuses",
+    "url": "https://httpstatuses.io"
+}

--- a/contents/_includes/code.njk
+++ b/contents/_includes/code.njk
@@ -20,7 +20,7 @@ extends layout.njk
 </div>
 
 <article class="code container">
-  <h2>{{ categories[set] | safe }}</h2>
+  <h2>{{ set }}&times;&times; {{ categories[set] }}</h2>
   <h1>
     <span>{{ code }}</span>
     {{ title }}

--- a/contents/_includes/code.njk
+++ b/contents/_includes/code.njk
@@ -4,7 +4,7 @@ extends layout.njk
 
 {% block title %}<title>{{ code }} {{ title }} &mdash; httpstatuses.io</title>{% endblock %}
 
-{% block description %}<meta name='description' content='HTTP Status Code {{ code }}: {{ content | striptags(true) | excerpt }}' />{% endblock %}
+{% block description %}<meta name='description' content='HTTP Status Code {{ code }}: {{ content | deletehtml | striptags(true) | excerpt }}' />{% endblock %}
 
 {% block contents %}
 <div class="banner">

--- a/contents/_includes/index.njk
+++ b/contents/_includes/index.njk
@@ -31,7 +31,7 @@
       {% for code, category in collections.codes %}
         <ul>
             <li>
-              <h2>{{ categories[code] | safe }}</h2>
+              <h2>{{ code }}&times;&times; {{ categories[code] }}</h2>
               {% for code in category %}
                 <li>
                   <a href="{{ code.data.code }}">

--- a/contents/codes/103.md
+++ b/contents/codes/103.md
@@ -7,7 +7,6 @@ code_references:
     ".NET HTTP Status Enum": "HttpStatusCode.EarlyHints"
     "Go HTTP Status Constant": "http.StatusEarlyHints"
 ---
-### Early Hints
 
 This status code indicates to the client that the server is likely to send a final response with the header fields included in the informational response.
 

--- a/contents/codes/202.md
+++ b/contents/codes/202.md
@@ -14,9 +14,7 @@ code_references:
     "Python3.5+ HTTP Status Constant": "http.HTTPStatus.ACCEPTED"
 ---
 
-The request has been accepted for processing, but the processing has not been
-completed. The request might or might not eventually be acted upon, as it might
-be disallowed when processing actually takes place.
+The request has been accepted for processing, but the processing has not been completed. The request might or might not eventually be acted upon, as it might be disallowed when processing actually takes place.
 
 There is no facility in HTTP for re-sending a status code from an asynchronous
 operation.

--- a/contents/codes/308.md
+++ b/contents/codes/308.md
@@ -10,8 +10,6 @@ code_references:
     "Symfony HTTP Status Constant": "Response::HTTP_PERMANENTLY_REDIRECT"
 ---
 
-### Permanent Redirect
-
 The target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.
 
 Clients with link editing capabilities ought to automatically re-link references to the effective request URI<sup>[1](#ref-1)</sup> to one or more of the new references sent by the server, where possible.

--- a/contents/codes_json.njk
+++ b/contents/codes_json.njk
@@ -8,5 +8,6 @@ permalink: '/{{ pagination.items[0].data.code }}.json'
   "status_code": {{ pagination.items[0].data.code }},
   "title": "{{ pagination.items[0].data.title }}",
   "description": {{ pagination.items[0].content | firstparagraph | dump | deletehtml | striptags | safe }},
-  "category": "{{ pagination.items[0].data.categories[pagination.items[0].data.set] }}", "html_url": "{{ site.url }}/{{ pagination.items[0].data.code }}"
+  "category": "{{ pagination.items[0].data.categories[pagination.items[0].data.set] }}",
+  "html_url": "{{ site.url }}/{{ pagination.items[0].data.code }}"
 }

--- a/contents/codes_json.njk
+++ b/contents/codes_json.njk
@@ -1,0 +1,12 @@
+---
+pagination:
+  data: collections.codes_json
+  size: 1
+permalink: '/{{ pagination.items[0].data.code }}.json'
+---
+{
+  "status_code": {{ pagination.items[0].data.code }},
+  "title": "{{ pagination.items[0].data.title }}",
+  "description": {{ pagination.items[0].content | firstparagraph | dump | deletehtml | striptags | safe }},
+  "category": "{{ pagination.items[0].data.categories[pagination.items[0].data.set] }}", "html_url": "{{ site.url }}/{{ pagination.items[0].data.code }}"
+}

--- a/contents/style.scss
+++ b/contents/style.scss
@@ -29,11 +29,6 @@ a {
   }
 }
 
-a[href^='https://www.runscope.com'] {
-  color: #1b70e0;
-  font-weight: bold;
-}
-
 h1, h2, h3, h4, h5, h6 {
   color: #333;
   font-size: 20px;
@@ -90,14 +85,12 @@ code {
   margin-bottom: 40px;
 
   ul {
-    font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
     font-size: 14px;
     letter-spacing: 0.5px;
     list-style-type: none;
     margin-bottom: 10px;
 
     h2 {
-      font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
       font-size: 14px;
       margin-bottom: 6px;
     }

--- a/lib/filters/decode.js
+++ b/lib/filters/decode.js
@@ -1,0 +1,6 @@
+const he = require('he');
+
+// decodes any HTML entities produced as part of markdown process
+const decode = str => he.decode(str);
+
+module.exports = decode;

--- a/lib/filters/decode.test.js
+++ b/lib/filters/decode.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const decode = require('./decode.js');
+
+test('should decode entities', () => {
+  const input = "That&apos;s my box";
+  const want = "That's my box";
+
+  const got = decode(input);
+  assert.strictEqual(got, want);
+});
+

--- a/lib/filters/excerpt.js
+++ b/lib/filters/excerpt.js
@@ -6,11 +6,9 @@ const firstParagraph = require('./first-paragraph');
 const DEFAULT_LENGTH = 50;
 
 // Extracts the first line of a string, then truncates to `length`,
-// decodes any HTML entities produced as part of markdown process.
 function excerpt(str, length = DEFAULT_LENGTH) {
   const content = firstParagraph(str);
-  const decoded = he.decode(content);
-  return prune(decoded, length);
+  return prune(content, length);
 }
 
 module.exports = excerpt;

--- a/lib/filters/excerpt.js
+++ b/lib/filters/excerpt.js
@@ -1,17 +1,15 @@
 const prune = require('voca/prune');
 const he = require('he');
 
+const firstParagraph = require('./first-paragraph');
+
 const DEFAULT_LENGTH = 50;
 
 // Extracts the first line of a string, then truncates to `length`,
 // decodes any HTML entities produced as part of markdown process.
 function excerpt(str, length = DEFAULT_LENGTH) {
-  if (str.length === 0) {
-    return str;
-  }
-
-  const firstParagraph = str.split("\n")[0];
-  const decoded = he.decode(firstParagraph);
+  const content = firstParagraph(str);
+  const decoded = he.decode(content);
   return prune(decoded, length);
 }
 

--- a/lib/filters/first-paragraph.js
+++ b/lib/filters/first-paragraph.js
@@ -1,0 +1,7 @@
+function firstParagraph(str) {
+    const trimmed = str.trim();
+    const firstLine = trimmed.split("\n")[0];
+    return firstLine.trim();
+}
+
+module.exports = firstParagraph;

--- a/lib/filters/first-paragraph.test.js
+++ b/lib/filters/first-paragraph.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const firstParagraph = require('./first-paragraph.js');
+
+test('returns content before first newline', () => {
+  const input = `The quick
+  
+brown fox
+jumped`;
+  const want = "The quick";
+
+  const got = firstParagraph(input, 12);
+  assert.strictEqual(got, want);
+});
+
+test('should strip trailing whitespace on selected line', () => {
+  const input = `The quick          
+    
+brown fox
+jumped`;
+  const want = "The quick";
+  
+  const got = firstParagraph(input, 12);
+  assert.strictEqual(got, want);
+});
+
+test('strips leading whitespace on document', () => {
+  const input = `
+  
+The quick          
+
+brown fox
+jumped`;
+  const want = "The quick";
+
+  const got = firstParagraph(input, 12);
+  assert.strictEqual(got, want);
+});

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -1,0 +1,7 @@
+const firstParagraph = require('./first-paragraph');
+const excerpt = require('./excerpt');
+
+module.exports = {
+    excerpt,
+    firstParagraph
+}

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -1,8 +1,10 @@
 const removeHTMLElements = require('./remove-html-elements')
 const firstParagraph = require('./first-paragraph');
 const excerpt = require('./excerpt');
+const decode = require('./decode');
 
 module.exports = {
+    decode,
     excerpt,
     firstParagraph,
     removeHTMLElements

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -1,7 +1,9 @@
+const removeHTMLElements = require('./remove-html-elements')
 const firstParagraph = require('./first-paragraph');
 const excerpt = require('./excerpt');
 
 module.exports = {
     excerpt,
-    firstParagraph
+    firstParagraph,
+    removeHTMLElements
 }

--- a/lib/filters/remove-html-elements.js
+++ b/lib/filters/remove-html-elements.js
@@ -1,0 +1,16 @@
+function removeHTMLElements({ str, stripSpaces = true, tags } = { str: "", stripSpaces: true }) {
+    for (const tag of tags) {
+        const formattedTag = `<${tag}>.*?</${tag}>`;
+        const regex = new RegExp(formattedTag, 'g');
+        str = str.replace(regex, "");
+    }
+
+    if (stripSpaces) {
+        str = str.replace(/ {2,}/g, ' ');
+        str = str.trim();
+    }
+
+    return str;
+}
+
+module.exports = removeHTMLElements;

--- a/lib/filters/remove-html-elements.test.js
+++ b/lib/filters/remove-html-elements.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const removeHTMLElements = require('./remove-html-elements');
+
+test('removes provided HTML element from string input, stripping extra spaces by default', () => {
+  const input = "The<b>quick</b> brown fox jumped";
+  const want = "The brown fox jumped";
+
+  const got = removeHTMLElements({ str: input, tags: ["b"] });
+  assert.strictEqual(got, want);
+});
+
+test('supports providing multiple HTML elements to remove', () => {
+  const input = "The <b>quick</b> <i>brown</i> <div>fox</div> jumped";
+  const want = "The <div>fox</div> jumped";
+
+  const got = removeHTMLElements({ str: input, tags: ["b", "i"] });
+  assert.strictEqual(got, want);
+});
+
+test('supports preserving spaces created by deletion', () => {
+  const input = "The <b>quick</b> <i>brown</i> <div>fox</div> jumped";
+  const want = "The   <div>fox</div> jumped";
+
+  const got = removeHTMLElements({ str: input, tags: ["b", "i"], stripSpaces: false });
+  assert.strictEqual(got, want);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "httpstatuses",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "httpstatuses",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "httpstatuses",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "An easy to reference directory of HTTP Status Codes",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## JSON Endpoints

This PR adds JSON endpoints as requested in https://github.com/httpstatuses/httpstatuses/issues/12, available at `{site_url}/{code}.json`. The `description` field is the first paragraph of the full code document.

Example for code /200.json:
```json
{
  "status_code": 200,
  "title": "OK",
  "description": "The request has succeeded.",
  "category": "Success",
  "html_url": "https://httpstatuses.io/200"
}
```

### Other changes

This PR also fixes an issue where the numbers from `<sup>` elements from the documents could sneak their way into the `<meta name="description"` element on some pages.

Example (see ending):
```html
<meta name="description" content="HTTP Status Code 203: The request was successful but the enclosed payload has been modified from that of the origin server's 200 OK response by a transforming proxy1.">
```
