### PR TITLE
Code 425 style tweak

### DIFF
--- a/contents/codes/425.md
+++ b/contents/codes/425.md
@@ -20,6 +20,7 @@ In all cases, an intermediary can forward a 425 (Too Early) status code. Interme
 The server cannot assume that a client is able to retry a request unless the request is received in early data or the Early-Data header field is set to "1".  A server SHOULD NOT emit the 425 status code unless one of these conditions is met.
 
 The 425 (Too Early) status code is not cacheable by default. Its payload is not the representation of any identified resource.
+
 ---
 
 * Source: [RFC4918 Section 5.2][1]


### PR DESCRIPTION
Adds a missing newline to 425.md where a piece of content was being incorrectly rendered as a heading